### PR TITLE
AETHER-2284 Some of the descriptions gets truncated and covers the remaining string with dots

### DIFF
--- a/src/app/aether-ap-list/ap-list/ap-list.component.html
+++ b/src/app/aether-ap-list/ap-list/ap-list.component.html
@@ -37,7 +37,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descriptionColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:50}}</td>
         </ng-container>
 
         <ng-container matColumnDef="enterprise" id="enterpriseColumn">

--- a/src/app/aether-application/application/application.component.html
+++ b/src/app/aether-application/application/application.component.html
@@ -28,7 +28,7 @@
         <!-- Description Name Column -->
         <ng-container matColumnDef="description" id="descriptionColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:40}}</td>
         </ng-container>
 
         <!-- End-Points Column -->

--- a/src/app/aether-connectivity-service/connectivity-service-edit/connectivity-service-edit.component.ts
+++ b/src/app/aether-connectivity-service/connectivity-service-edit/connectivity-service-edit.component.ts
@@ -35,7 +35,7 @@ export class ConnectivityServiceEditComponent extends RocEditBase<ConnectivitySe
         ])],
         description: [undefined, Validators.compose([
             Validators.minLength(1),
-            Validators.maxLength(80),
+            Validators.maxLength(1024),
         ])],
         'spgwc-endpoint': [undefined, Validators.compose([
             Validators.minLength(1),

--- a/src/app/aether-connectivity-service/connectivity-service/connectivity-service.component.html
+++ b/src/app/aether-connectivity-service/connectivity-service/connectivity-service.component.html
@@ -25,7 +25,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:25}}</td>
         </ng-container>
 
         <!-- SPGW-C Endpoint Column -->

--- a/src/app/aether-device-group/device-group-edit/device-group-edit.component.ts
+++ b/src/app/aether-device-group/device-group-edit/device-group-edit.component.ts
@@ -72,7 +72,7 @@ export class DeviceGroupEditComponent extends RocEditBase<DeviceGroupDeviceGroup
         ])],
         description: [undefined, Validators.compose([
             Validators.minLength(1),
-            Validators.maxLength(80),
+            Validators.maxLength(1024),
         ])],
         'display-name': [undefined, Validators.compose([
             Validators.minLength(1),

--- a/src/app/aether-device-group/device-group/device-group.component.html
+++ b/src/app/aether-device-group/device-group/device-group.component.html
@@ -28,7 +28,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:30}}</td>
         </ng-container>
 
         <!-- Imsis Column -->

--- a/src/app/aether-enterprise/enterprise/enterprise.component.html
+++ b/src/app/aether-enterprise/enterprise/enterprise.component.html
@@ -25,7 +25,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:80}}</td>
         </ng-container>
 
         <!-- Connectivity Column -->

--- a/src/app/aether-ip-domain/ip-domain-edit/ip-domain-edit.component.ts
+++ b/src/app/aether-ip-domain/ip-domain-edit/ip-domain-edit.component.ts
@@ -50,7 +50,7 @@ export class IpDomainEditComponent extends RocEditBase<IpDomainIpDomain> impleme
         ])],
         description: [undefined, Validators.compose([
             Validators.minLength(1),
-            Validators.maxLength(80),
+            Validators.maxLength(1024),
         ])],
         enterprise: [undefined, Validators.required],
         'dns-primary': [undefined],

--- a/src/app/aether-ip-domain/ip-domain/ip-domain.component.html
+++ b/src/app/aether-ip-domain/ip-domain/ip-domain.component.html
@@ -30,7 +30,7 @@
         <!--Description Column-->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:40}}</td>
         </ng-container>
 
         <!-- Enterprise Column-->

--- a/src/app/aether-site/site-edit/site-edit.component.ts
+++ b/src/app/aether-site/site-edit/site-edit.component.ts
@@ -36,7 +36,7 @@ export class SiteEditComponent extends RocEditBase<SiteSite> implements OnInit {
         ])],
         description: [undefined, Validators.compose([
             Validators.minLength(1),
-            Validators.maxLength(80),
+            Validators.maxLength(1024),
         ])],
         enterprise: [undefined],
         'imsi-definition': this.fb.group({

--- a/src/app/aether-site/site/site.component.html
+++ b/src/app/aether-site/site/site.component.html
@@ -25,7 +25,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:40}}</td>
         </ng-container>
 
         <!-- Enterprise Column -->

--- a/src/app/aether-template/template/template.component.html
+++ b/src/app/aether-template/template/template.component.html
@@ -25,7 +25,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:35}}</td>
         </ng-container>
 
         <!-- SD Column -->

--- a/src/app/aether-traffic-class/traffic-class/traffic-class.component.html
+++ b/src/app/aether-traffic-class/traffic-class/traffic-class.component.html
@@ -26,7 +26,7 @@
         <!-- Description Name Column -->
         <ng-container matColumnDef="description" id="descriptionColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:50}}</td>
         </ng-container>
 
         <!-- PELR Column -->

--- a/src/app/aether-upf/upf/upf.component.html
+++ b/src/app/aether-upf/upf/upf.component.html
@@ -27,7 +27,7 @@
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Description</th>
-            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:20}}</td>
+            <td mat-cell  *matCellDef="let row" [title]="row.description">{{row.description | truncateText:35}}</td>
         </ng-container>
 
         <ng-container matColumnDef="enterprise" id="enterpriseColumn">


### PR DESCRIPTION
Also some description were being limited to 80 - should have been 1024

The limit of characters before truncation has been adjusted to take account of the number of columns in that view. Some are crowded e.g. `VCS`, some are not e.g. `enterprise`:

- ap-list: 50
- application: 40
- connectivity-service: 25
- device-group: 30
- enterprise: 80
- ip-domain: 40
- site: 40
- template: 35
- traffic-class: 50
- upf: 35
