### PR TITLE
AETHER-2377 add a button to GUI to repush the configuration from ROC to SD-CORE

### DIFF
--- a/src/app/aether-ip-domain/ip-domain-edit/ip-domain-edit.component.html
+++ b/src/app/aether-ip-domain/ip-domain-edit/ip-domain-edit.component.html
@@ -92,7 +92,7 @@
             <div class="row">
                 <mat-form-field class="field-margin half-width">
                     <mat-label>{{this.displayOption}}</mat-label>
-                    <mat-select formControlName="admin-status" [(value)]="this.option">
+                    <mat-select formControlName="admin-status" [(value)]="this.option" id="selectAdminStatus">
                         <mat-option id="statusOptionEnabled" value="ENABLE" (click)="changeAdminStatus()">ENABLE
                         </mat-option>
                         <mat-option id="statusOptionDisabled" value="DISABLE" (click)="changeAdminStatus()">DISABLE

--- a/src/app/aether-routing.module.ts
+++ b/src/app/aether-routing.module.ts
@@ -61,6 +61,10 @@ const aetherRoutes: Routes = [
         loadChildren: () => import('./aether-traffic-class/traffic-class.module').then(m => m.TrafficClassModule)
     },
     {
+        path: 'diagnostics',
+        loadChildren: () => import('./diagnostics/diagnostics.module').then(m => m.DiagnosticsModule)
+    },
+    {
         path: '',
         redirectTo: 'dashboard',
         pathMatch: 'full'

--- a/src/app/aether-vcs/vcs-edit/vcs-edit.component.ts
+++ b/src/app/aether-vcs/vcs-edit/vcs-edit.component.ts
@@ -145,9 +145,6 @@ export class VcsEditComponent extends RocEditBase<VcsVcs> implements OnInit {
             this.vcsForm.get('template').disable();
             this.vcsForm.get('sd').disable();
             this.vcsForm.get('sst').disable();
-            this.vcsForm.get(['device', 'mbr', 'uplink']).disable();
-            this.vcsForm.get(['device', 'mbr', 'downlink']).disable();
-            this.vcsForm.get('traffic-class').disable();
         }
         this.loadDeviceGoup(this.target);
         this.loadTemplate(this.target);

--- a/src/app/aether.component.html
+++ b/src/app/aether.component.html
@@ -73,6 +73,11 @@
             <mat-icon>vpn_key</mat-icon>
             <span>API Key</span>
         </button>
+        <button *ngIf="opaService.userGroups.includes(AETHER_ROC_ADMIN_USER)" mat-menu-item routerLink="/diagnostics"
+                id="diagnosticsButton">
+            <mat-icon>bug_report</mat-icon>
+            <span>Diagnostics</span>
+        </button>
         <button mat-menu-item (click)="showhelp()"
                 id="showHelpButton">
             <mat-icon>help</mat-icon>

--- a/src/app/aether.component.ts
+++ b/src/app/aether.component.ts
@@ -8,7 +8,7 @@ import {OAuthService} from 'angular-oauth2-oidc';
 import {authConfig, BASKET_SERVICE_ENABLED} from '../environments/environment';
 import {Meta} from '@angular/platform-browser';
 import {BasketService} from './basket.service';
-import {OpenPolicyAgentService} from './open-policy-agent.service';
+import {AETHER_ROC_ADMIN_USER, OpenPolicyAgentService} from './open-policy-agent.service';
 import {Router} from '@angular/router';
 import {IdTokClaims} from './idtoken';
 import {SocketService} from './socket.service';
@@ -30,7 +30,7 @@ export class AetherComponent implements OnInit, OnDestroy {
     userProfileDisplay: boolean = false;
     apiKeyDisplay: boolean = false;
     basketServiceEnabled: boolean = BASKET_SERVICE_ENABLED;
-
+    AETHER_ROC_ADMIN_USER = AETHER_ROC_ADMIN_USER
     constructor(
         private oauthService: OAuthService,
         private meta: Meta,

--- a/src/app/common-profiles.component.scss
+++ b/src/app/common-profiles.component.scss
@@ -21,6 +21,10 @@
     padding-right: 20px;
 }
 
+.space-allround {
+    padding: 20px;
+}
+
 .small-spacing {
     padding-right: 10px;
 }

--- a/src/app/diagnostics/diagnostics.module.ts
+++ b/src/app/diagnostics/diagnostics.module.ts
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: 2021-present Open Networking Foundation <info@opennetworking.org>
+ *
+ * SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+ */
+
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {SdcoreComponent} from './sdcore/sdcore.component';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {ApiModule as ApiModuleAether} from '../../openapi3/top/level/api.module';
+import {AETHER_ROC_API_URL, SDCORE_ADAPTER} from '../../environments/environment';
+import {HttpClientModule} from '@angular/common/http';
+import {RouterModule} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {AuthInterceptor} from '../auth-interceptor';
+import {API_INTERCEPTOR_PROVIDER} from '../aether.module';
+import {MatCardModule} from '@angular/material/card';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+
+@NgModule({
+    declarations: [
+        SdcoreComponent
+    ],
+    imports: [
+        CommonModule,
+        ApiModuleAether.forRoot({rootUrl: AETHER_ROC_API_URL}),
+        HttpClientModule,
+        RouterModule.forChild([
+            {path: 'sdcore', component: SdcoreComponent},
+            {path: '', component: SdcoreComponent, pathMatch: 'full'}
+        ]),
+        MatToolbarModule,
+        MatButtonModule,
+        MatFormFieldModule,
+        MatCardModule,
+        MatSnackBarModule
+    ],
+    providers: [
+        AuthInterceptor,
+        API_INTERCEPTOR_PROVIDER,
+        {provide: 'sdcore-adapter-service', useValue: SDCORE_ADAPTER}
+    ]
+})
+export class DiagnosticsModule {
+}

--- a/src/app/diagnostics/sdcore/sdcore.component.html
+++ b/src/app/diagnostics/sdcore/sdcore.component.html
@@ -1,0 +1,20 @@
+<!--
+~ SPDX-FileCopyrightText: 2021-present Open Networking Foundation <info@opennetworking.org>
+~
+~ SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+-->
+<div>
+    <mat-toolbar class="profile-toolbar" color="primary">
+        <p>SD-CORE</p>
+        <span class="toolbar-spacer"></span>
+    </mat-toolbar>
+    <div class="space-allround">
+        <mat-label class="space-allround">{{sdcoreAdapter}}</mat-label>
+        <button mat-raised-button color="accent"
+                class="spacing"
+                type="submit"
+                [disabled]="!opaService.userGroups.includes(AETHER_ROC_ADMIN_USER)"
+                (click)="synchronize()"
+                id="synchronizeButton">Synchronize</button>
+    </div>
+</div>

--- a/src/app/diagnostics/sdcore/sdcore.component.spec.ts
+++ b/src/app/diagnostics/sdcore/sdcore.component.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2021-present Open Networking Foundation <info@opennetworking.org>
+ *
+ * SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+ */
+
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {SdcoreComponent} from './sdcore.component';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatIconModule} from '@angular/material/icon';
+import {ApiModule} from '../../../openapi3/top/level/api.module';
+import {MatCardModule} from '@angular/material/card';
+import {SDCORE_ADAPTER} from '../../../environments/environment';
+
+describe('SdcoreComponent', () => {
+    let component: SdcoreComponent;
+    let fixture: ComponentFixture<SdcoreComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [SdcoreComponent],
+            imports: [
+                HttpClientTestingModule,
+                RouterTestingModule,
+                BrowserAnimationsModule,
+                MatSnackBarModule,
+                MatToolbarModule,
+                MatIconModule,
+                MatCardModule,
+                ApiModule
+            ],
+            providers: [
+                {provide: 'sdcore-adapter-service', useValue: SDCORE_ADAPTER}
+            ]
+        })
+            .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SdcoreComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/src/app/diagnostics/sdcore/sdcore.component.ts
+++ b/src/app/diagnostics/sdcore/sdcore.component.ts
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: 2021-present Open Networking Foundation <info@opennetworking.org>
+ *
+ * SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+ */
+import {Component, Inject, Input, OnInit} from '@angular/core';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {OpenPolicyAgentService, AETHER_ROC_ADMIN_USER} from '../../open-policy-agent.service';
+import {ApiService as TopLevelApiService} from '../../../openapi3/top/level/services/api.service';
+
+@Component({
+    selector: 'aether-sdcore',
+    templateUrl: './sdcore.component.html',
+    styleUrls: ['../../common-profiles.component.scss']
+})
+export class SdcoreComponent {
+    AETHER_ROC_ADMIN_USER = AETHER_ROC_ADMIN_USER;
+
+    constructor(
+        private topLevelService: TopLevelApiService,
+        public opaService: OpenPolicyAgentService,
+        protected snackBar: MatSnackBar,
+        @Inject('sdcore-adapter-service') public sdcoreAdapter: string,
+    ) {
+    }
+
+    synchronize() {
+        this.topLevelService.sdcorePushConfigTopLevel({
+            service: this.sdcoreAdapter,
+        }).subscribe(
+            (value => {
+                this.snackBar.open('Synchronizing: ' + value , undefined, {duration: 2000});
+            }),
+            (err =>
+                this.snackBar.open('Error:' + err.error, 'Dismiss', {duration: 20000})
+            )
+        );
+    }
+
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -16,6 +16,7 @@ export const PROMETHEUS_PROXY = window.location.origin + '/prometheus';
 export const WEBSOCKET_PROXY = window.location.origin.toString().replace('http', 'ws') + '/ws';
 
 export const AETHER_TARGETS = ['connectivity-service-v4'];
+export const SDCORE_ADAPTER = 'sdcore-adapter-v4';
 
 export const OIDC_AUTH_CLIENT_ID = 'aether-roc-gui';
 export const OIDC_ISSUER = undefined;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -28,6 +28,7 @@ export const PROMETHEUS_PROXY = 'http://localhost:9090';
 export const WEBSOCKET_PROXY = 'ws://localhost:8120/ws';
 
 export const AETHER_TARGETS = ['connectivity-service-v4'];
+export const SDCORE_ADAPTER = 'sdcore-adapter-v4';
 export const RBAC_TARGET = 'rbac';
 
 export const OIDC_AUTH_CLIENT_ID = 'aether-roc-gui';

--- a/src/index.html
+++ b/src/index.html
@@ -16,6 +16,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <!--    <meta name="openidcissuer" content="https://dex.aetherproject.org/dex">-->
 <!--    <meta name="openidcissuer" content="http://dex-ldap-umbrella:5556">-->
+<!--    <meta name="openidcissuer" content="http://k3u-keycloak:5557/auth/realms/master">-->
     <meta name="openidcissuer" content="$OPENIDCISSUER">
 </head>
 <body>

--- a/src/openapi3/top/level/api.module.ts
+++ b/src/openapi3/top/level/api.module.ts
@@ -32,7 +32,7 @@ export class ApiModule {
     }
   }
 
-  constructor( 
+  constructor(
     @Optional() @SkipSelf() parentModule: ApiModule,
     @Optional() http: HttpClient
   ) {

--- a/src/openapi3/top/level/services/api.service.ts
+++ b/src/openapi3/top/level/services/api.service.ts
@@ -130,6 +130,68 @@ export class ApiService extends BaseService {
   }
 
   /**
+   * Path part for operation sdcorePushConfigTopLevel
+   */
+  static readonly SdcorePushConfigTopLevelPath = '/sdcore/synchronize/{service}';
+
+  /**
+   * POST /sdcore/synchronize/{service}.
+   *
+   *
+   *
+   * This method provides access to the full `HttpResponse`, allowing access to response headers.
+   * To access only the response body, use `sdcorePushConfigTopLevel()` instead.
+   *
+   * This method doesn't expect any request body.
+   */
+  sdcorePushConfigTopLevel$Response(params: {
+
+    /**
+     * sdcore service name e.g. sdcore-adapter-v4
+     */
+    service: any;
+  }): Observable<StrictHttpResponse<void>> {
+
+    const rb = new RequestBuilder(this.rootUrl, ApiService.SdcorePushConfigTopLevelPath, 'post');
+    if (params) {
+      rb.path('service', params.service, {});
+    }
+
+    return this.http.request(rb.build({
+      responseType: 'text',
+      accept: '*/*'
+    })).pipe(
+      filter((r: any) => r instanceof HttpResponse),
+      map((r: HttpResponse<any>) => {
+        return (r as HttpResponse<any>).clone({ body: undefined }) as StrictHttpResponse<void>;
+      })
+    );
+  }
+
+  /**
+   * POST /sdcore/synchronize/{service}.
+   *
+   *
+   *
+   * This method provides access to only to the response body.
+   * To access the full response (for headers, for example), `sdcorePushConfigTopLevel$Response()` instead.
+   *
+   * This method doesn't expect any request body.
+   */
+  sdcorePushConfigTopLevel(params: {
+
+    /**
+     * sdcore service name e.g. sdcore-adapter-v4
+     */
+    service: any;
+  }): Observable<void> {
+
+    return this.sdcorePushConfigTopLevel$Response(params).pipe(
+      map((r: StrictHttpResponse<void>) => r.body as void)
+    );
+  }
+
+  /**
    * Path part for operation specTopLevel
    */
   static readonly SpecTopLevelPath = '/spec';


### PR DESCRIPTION
Supported in aether-roc-api v0.8.0

also
* AETHER-2328 Unique ID required for various fields
* AETHER-2331 VCS edit page does not allow editing of bandwidth after initial creation
