### PR TITLE
Using id instead of names for Site monitor

### DIFF
--- a/src/app/aether-site/site-monitor/site-monitor.component.ts
+++ b/src/app/aether-site/site-monitor/site-monitor.component.ts
@@ -111,7 +111,7 @@ export class SiteMonitorComponent extends RocMonitorBase implements OnInit, OnDe
 
         // Filter for Monitoring agents
         this.thisSite.monitoring["edge-device"].forEach((device) => {
-            baseUrl += `&var-agents=${device.name}`
+            baseUrl += `&var-agents=${device['edge-device-id']}`
         })
 
         return baseUrl;
@@ -126,7 +126,7 @@ export class SiteMonitorComponent extends RocMonitorBase implements OnInit, OnDe
 
         // Filter for ENBs
         this.thisSite["small-cell"].forEach((enb) => {
-            baseUrl += `&var-enb=${enb.name}`
+            baseUrl += `&var-enb=${enb['small-cell-id']}`
         })
 
         return baseUrl;

--- a/src/app/utils/site-prom-data-source.ts
+++ b/src/app/utils/site-prom-data-source.ts
@@ -53,11 +53,11 @@ export class SitePromDataSource {
         switch (tag) {
             case "agentsSum":
                 host = site.monitoring["edge-monitoring-prometheus-url"]
-                query = `sum(aetheredge_e2e_tests_ok{name=~"${site.monitoring["edge-device"].map((device) => device.name).join("|")}"})`
+                query = `sum(aetheredge_e2e_tests_ok{name=~"${site.monitoring["edge-device"].map((device) => device['edge-device-id']).join("|")}"})`
                 break
             case "agentsCount":
                 host = site.monitoring["edge-monitoring-prometheus-url"]
-                query = `count(aetheredge_e2e_tests_ok{name=~"${site.monitoring["edge-device"].map((device) => device.name).join("|")}"})`
+                query = `count(aetheredge_e2e_tests_ok{name=~"${site.monitoring["edge-device"].map((device) => device['edge-device-id']).join("|")}"})`
                 break
             case "clusterNodesSum":
                 host = site.monitoring["edge-cluster-prometheus-url"]


### PR DESCRIPTION
Using id instead of names for Site monitor pages as per new change in model