### PR TITLE
AETHER-2682 add back in PDB & PELR fields in traffic-class

### DIFF
--- a/src/app/aether-template/template-edit/template-edit.component.html
+++ b/src/app/aether-template/template-edit/template-edit.component.html
@@ -60,10 +60,10 @@
                 <div [formGroup]="sliceMbrControls">
                     <div class="row float-left" id="uplinkRow">
                         <mat-form-field class="field-margin">
-                            <input matInput type="number" [matAutocomplete]="auto"
+                            <input matInput type="number" [matAutocomplete]="uplinkAuto"
                                    id="inputsliceUplink"
                                    formControlName="uplink">
-                            <mat-autocomplete #auto="matAutocomplete">
+                            <mat-autocomplete #uplinkAuto="matAutocomplete">
                                 <mat-option *ngFor="let option of bandwidthOptions | async"
                                             [value]="option.megabyte.numerical">
                                     {{option.megabyte.numerical}}
@@ -75,10 +75,10 @@
                     </div>
                     <div class="row " id="downlinkRow">
                         <mat-form-field class="field-margin">
-                            <input matInput type="number" [matAutocomplete]="auto"
+                            <input matInput type="number" [matAutocomplete]="downlinkAuto"
                                    id="inputsliceDownlink"
                                    formControlName="downlink">
-                            <mat-autocomplete #auto="matAutocomplete">
+                            <mat-autocomplete #downlinkAuto="matAutocomplete">
                                 <mat-option *ngFor="let option of bandwidthOptions | async"
                                             [value]="option.megabyte.numerical">
                                     {{option.megabyte.numerical}}
@@ -86,6 +86,34 @@
                                 </mat-option>
                             </mat-autocomplete>
                             <mat-hint>Downlink (bps)</mat-hint>
+                        </mat-form-field>
+                    </div>
+                    <div class="row float-left" id="sliceUplinkBurstSizeRow">
+                        <mat-form-field class="field-margin">
+                            <input matInput type="number" [matAutocomplete]="burstauto"
+                                   id="inputsliceUplinkBurstSize"
+                                   formControlName="uplink-burst-size">
+                            <mat-autocomplete #burstauto="matAutocomplete">
+                                <mat-option *ngFor="let option of burstRateOptions"
+                                            [value]="option.value">
+                                    {{option.label}}
+                                </mat-option>
+                            </mat-autocomplete>
+                            <mat-hint>Uplink Burst Size (bytes)</mat-hint>
+                        </mat-form-field>
+                    </div>
+                    <div class="row " id="sliceDownlinkBurstSizeRow">
+                        <mat-form-field class="field-margin">
+                            <input matInput type="number" [matAutocomplete]="burstauto"
+                                   id="inputsliceDownlinkBurstSize"
+                                   formControlName="downlink-burst-size">
+                            <mat-autocomplete #burstauto="matAutocomplete">
+                                <mat-option *ngFor="let option of burstRateOptions"
+                                            [value]="option.value">
+                                    {{option.label}}
+                                </mat-option>
+                            </mat-autocomplete>
+                            <mat-hint>Downlink Burst Size (bytes)</mat-hint>
                         </mat-form-field>
                     </div>
                 </div>

--- a/src/app/aether-template/template-edit/template-edit.component.ts
+++ b/src/app/aether-template/template-edit/template-edit.component.ts
@@ -22,6 +22,11 @@ export interface Bandwidths {
     megabyte: { numerical: number, inMb: string };
 }
 
+interface BurstRate {
+    value: number
+    label: string
+}
+
 @Component({
     selector: 'aether-template-edit',
     templateUrl: './template-edit.component.html',
@@ -54,6 +59,18 @@ export class TemplateEditComponent extends RocEditBase<TemplateTemplate> impleme
         {megabyte: {numerical: 100000000, inMb: '100Mbps'}},
         {megabyte: {numerical: 500000000, inMb: '500Mbps'}}
     ];
+
+    burstRateOptions: BurstRate[] = [
+        {label: '125 KB', value: 125000},
+        {label: '250 KB', value: 250000},
+        {label: '375 KB', value: 375000},
+        {label: '500 KB', value: 500000},
+        {label: '625 KB', value: 625000},
+        {label: '750 KB', value: 750000},
+        {label: '875 KB', value: 875000},
+        {label: '1 MB', value: 1000000},
+    ]
+
     bandwidthOptions: Observable<Bandwidths[]>;
     data: TemplateTemplate;
     tempForm = this.fb.group({
@@ -82,18 +99,6 @@ export class TemplateEditComponent extends RocEditBase<TemplateTemplate> impleme
             Validators.min(1),
             Validators.max(255)
         ])],
-        device: this.fb.group({
-            mbr: this.fb.group({
-                uplink: [undefined, Validators.compose([
-                    Validators.min(0),
-                    Validators.max(4294967295)
-                ])],
-                downlink: [undefined, Validators.compose([
-                    Validators.min(0),
-                    Validators.max(4294967295)
-                ])]
-            }),
-        }),
         slice: this.fb.group({
             mbr: this.fb.group({
                 uplink: [undefined, Validators.compose([
@@ -101,6 +106,14 @@ export class TemplateEditComponent extends RocEditBase<TemplateTemplate> impleme
                     Validators.max(4294967295)
                 ])],
                 downlink: [undefined, Validators.compose([
+                    Validators.min(0),
+                    Validators.max(4294967295)
+                ])],
+                'uplink-burst-size': [undefined, Validators.compose([
+                    Validators.min(0),
+                    Validators.max(4294967295)
+                ])],
+                'downlink-burst-size': [undefined, Validators.compose([
                     Validators.min(0),
                     Validators.max(4294967295)
                 ])]
@@ -134,10 +147,10 @@ export class TemplateEditComponent extends RocEditBase<TemplateTemplate> impleme
             );
         this.tempForm.get('sd')[TYPE] = HEX2NUM;
         this.tempForm.get('sst')[TYPE] = 'number';
-        this.tempForm.get(['device','mbr','uplink'])[TYPE] = 'number';
-        this.tempForm.get(['device','mbr','downlink'])[TYPE] = 'number';
         this.tempForm.get(['slice','mbr','uplink'])[TYPE] = 'number';
         this.tempForm.get(['slice','mbr','downlink'])[TYPE] = 'number';
+        this.tempForm.get(['slice','mbr','uplink-burst-size'])[TYPE] = 'number';
+        this.tempForm.get(['slice','mbr','downlink-burst-size'])[TYPE] = 'number';
     }
 
     private _filter(bandwidthIndex: number): Bandwidths[] {
@@ -196,13 +209,13 @@ export class TemplateEditComponent extends RocEditBase<TemplateTemplate> impleme
         if (value.slice && value.slice.mbr) {
             this.tempForm.get(['slice','mbr','uplink']).setValue(value.slice.mbr.uplink);
             this.tempForm.get(['slice','mbr','downlink']).setValue(value.slice.mbr.downlink);
+            this.tempForm.get(['slice','mbr','uplink-burst-size']).setValue(value.slice.mbr['uplink-burst-size']);
+            this.tempForm.get(['slice','mbr','downlink-burst-size']).setValue(value.slice.mbr['downlink-burst-size']);
             this.tempForm.get(['slice','mbr','uplink'])[ORIGINAL] = value.slice.mbr.uplink;
             this.tempForm.get(['slice','mbr','downlink'])[ORIGINAL] = value.slice.mbr.downlink;
+            this.tempForm.get(['slice','mbr','uplink-burst-size'])[ORIGINAL] = value.slice.mbr['uplink-burst-size'];
+            this.tempForm.get(['slice','mbr','downlink-burst-size'])[ORIGINAL] = value.slice.mbr['downlink-burst-size'];
         }
-    }
-
-    get deviceMbrControls(): FormGroup {
-        return this.tempForm.get(['device','mbr']) as FormGroup;
     }
 
     get sliceMbrControls(): FormGroup {

--- a/src/app/aether-template/template/template.component.html
+++ b/src/app/aether-template/template/template.component.html
@@ -46,12 +46,21 @@
             <td mat-cell *matCellDef="let row" [title]="row['default-behavior']">{{row['default-behavior']}}</td>
         </ng-container>
 
-        <!-- slice Column -->
-        <ng-container matColumnDef="slice" id="sliceColumn">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header disabled>Slice</th>
+        <!-- mbr Column -->
+        <ng-container matColumnDef="mbr" id="mbrColumn">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header disabled>Slice MBR (bps)</th>
             <td mat-cell *matCellDef="let row">
-                <p><mat-icon class="small_icon">arrow_upward</mat-icon>{{row.slice.mbr.uplink}}</p>
-                <p><mat-icon class="small_icon">arrow_downward</mat-icon>{{row.slice.mbr.downlink}}</p>
+                <p *ngIf="row.slice && row.slice.mbr"><mat-icon class="small_icon">arrow_upward</mat-icon>{{row.slice.mbr.uplink}}</p>
+                <p *ngIf="row.slice && row.slice.mbr"><mat-icon class="small_icon">arrow_downward</mat-icon>{{row.slice.mbr.downlink}}</p>
+            </td>
+        </ng-container>
+
+        <!-- burst Column -->
+        <ng-container matColumnDef="burst" id="burstColumn">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header disabled>Slice Burst Size (Byte)</th>
+            <td mat-cell *matCellDef="let row">
+                <p *ngIf="row.slice && row.slice.mbr"><mat-icon class="small_icon">arrow_upward</mat-icon>{{row.slice.mbr['uplink-burst-size']}}</p>
+                <p *ngIf="row.slice && row.slice.mbr"><mat-icon class="small_icon">arrow_downward</mat-icon>{{row.slice.mbr['downlink-burst-size']}}</p>
             </td>
         </ng-container>
 

--- a/src/app/aether-template/template/template.component.ts
+++ b/src/app/aether-template/template/template.component.ts
@@ -33,7 +33,8 @@ export class TemplateComponent extends RocListBase<TemplateDatasource> implement
         'sd',
         'sst',
         'default-behavior',
-        'slice',
+        'mbr',
+        'burst',
         'edit',
         'delete'
     ];

--- a/src/app/aether-traffic-class/traffic-class-edit/traffic-class-edit.component.html
+++ b/src/app/aether-traffic-class/traffic-class-edit/traffic-class-edit.component.html
@@ -34,16 +34,28 @@
                     <mat-hint>Description</mat-hint>
                 </mat-form-field>
             </div>
+            <div class="row" id="pelrRow">
+                <mat-form-field class="field-margin half-width">
+                    <input matInput type=number formControlName="pelr" id="inputPelr">
+                    <mat-hint>Packet Error Loss Rate (PELR) exponent (0-10)</mat-hint>
+                </mat-form-field>
+            </div>
+            <div class="row" id="pdbRow">
+                <mat-form-field class="field-margin half-width">
+                    <input matInput type=number formControlName="pdb" id="inputPdb">
+                    <mat-hint>Packet Delay Budget (PDB) (0-1000)</mat-hint>
+                </mat-form-field>
+            </div>
             <div class="row" id="arpRow">
                 <mat-form-field class="field-margin half-width">
                     <input matInput type=number formControlName="arp" id="inputArp">
-                    <mat-hint>Allocation and Retention Priority</mat-hint>
+                    <mat-hint>Allocation and Retention Priority (ARP) (1-15)</mat-hint>
                 </mat-form-field>
             </div>
             <div class="row" id="qciRow">
                 <mat-form-field class="field-margin half-width">
                     <input matInput type=number formControlName="qci" id="inputQci">
-                    <mat-hint>QoS Class Identifier (QCI)</mat-hint>
+                    <mat-hint>QoS Class Identifier (QCI) (1-32)</mat-hint>
                 </mat-form-field>
             </div>
         </mat-card-content>

--- a/src/app/aether-traffic-class/traffic-class-edit/traffic-class-edit.component.ts
+++ b/src/app/aether-traffic-class/traffic-class-edit/traffic-class-edit.component.ts
@@ -50,6 +50,14 @@ export class TrafficClassEditComponent extends RocEditBase<TrafficClassTrafficCl
             Validators.min(1),
             Validators.max(32)
         ])],
+        pelr: [undefined, Validators.compose([
+            Validators.min(0),
+            Validators.max(10)
+        ])],
+        pdb: [undefined, Validators.compose([
+            Validators.min(0),
+            Validators.max(1000)
+        ])],
     });
 
     constructor(
@@ -105,6 +113,14 @@ export class TrafficClassEditComponent extends RocEditBase<TrafficClassTrafficCl
         if (value.description) {
             this.tcForm.get('description').setValue(value.description);
             this.tcForm.get('description')[ORIGINAL] = value.description;
+        }
+        if (value.pelr) {
+            this.tcForm.get('pelr').setValue(value.pelr);
+            this.tcForm.get('pelr')[ORIGINAL] = value.pelr;
+        }
+        if (value.pdb) {
+            this.tcForm.get('pdb').setValue(value.pdb);
+            this.tcForm.get('pdb')[ORIGINAL] = value.pdb;
         }
         if (value.arp) {
             this.tcForm.get('arp').setValue(value.arp);

--- a/src/app/aether-vcs/vcs-edit/vcs-edit.component.html
+++ b/src/app/aether-vcs/vcs-edit/vcs-edit.component.html
@@ -218,7 +218,7 @@
                                     {{option.label}}
                                 </mat-option>
                             </mat-autocomplete>
-                            <mat-hint>Uplink Burst Size (Mbps)</mat-hint>
+                            <mat-hint>Uplink Burst Size (bytes)</mat-hint>
                         </mat-form-field>
                     </div>
                     <div class="row " id="sliceDownlinkBurstSizeRow">
@@ -232,7 +232,7 @@
                                     {{option.label}}
                                 </mat-option>
                             </mat-autocomplete>
-                            <mat-hint>Downlink Burst Size (Mbps)</mat-hint>
+                            <mat-hint>Downlink Burst Size (bytes)</mat-hint>
                         </mat-form-field>
                     </div>
                 </div>

--- a/src/app/aether-vcs/vcs-edit/vcs-edit.component.ts
+++ b/src/app/aether-vcs/vcs-edit/vcs-edit.component.ts
@@ -57,14 +57,14 @@ export class VcsEditComponent extends RocEditBase<VcsVcs> implements OnInit {
     ];
 
     burstRateOptions: BurstRate[] = [
-        {label: '125 Kbps', value: 125000},
-        {label: '250 Kbps', value: 250000},
-        {label: '375 Kbps', value: 375000},
-        {label: '500 Kbps', value: 500000},
-        {label: '625 Kbps', value: 625000},
-        {label: '750 Kbps', value: 750000},
-        {label: '875 Kbps', value: 875000},
-        {label: '1 Mbps', value: 1000000},
+        {label: '125 KB', value: 125000},
+        {label: '250 KB', value: 250000},
+        {label: '375 KB', value: 375000},
+        {label: '500 KB', value: 500000},
+        {label: '625 KB', value: 625000},
+        {label: '750 KB', value: 750000},
+        {label: '875 KB', value: 875000},
+        {label: '1 MB', value: 1000000},
     ]
 
     defaultBehaviorOptions = [

--- a/src/app/aether-vcs/vcs-monitor/vcs-monitor.component.html
+++ b/src/app/aether-vcs/vcs-monitor/vcs-monitor.component.html
@@ -149,7 +149,7 @@
                     </h3>
                     <div>
                         <p>
-                            <small>PELR</small>&nbsp;{{trafficClass.pelr}}&nbsp;<small>PDB</small>&nbsp;{{trafficClass.pdb}}&nbsp;<small>QCI</small>&nbsp;{{trafficClass.qci}}
+                            <small>PELR</small>&nbsp;{{trafficClass.pelr}}&nbsp;<small>PDB</small>&nbsp;{{trafficClass.pdb}}&nbsp;<small>ARP</small>&nbsp;{{trafficClass.arp}}&nbsp;<small>QCI</small>&nbsp;{{trafficClass.qci}}
                         </p>
                     </div>
                 </mat-expansion-panel>


### PR DESCRIPTION
Also fixed problems in **Template** Edit and List pages:

- Added the `uplink-burst-size` and `downlink-burst-size` fields to edit page
- Fixed the auto-complte on `uplink` and `downlink` (was showing `DENY-ALL` etc
- Added the Burst rates to the list page
- On VCS edit changed the hint for `uplink-burst-size` and `downlink-burst-size` to say `Bytes` rather than `Mbps`