### PR TITLE
Using display name to filter ENB metrics

### DIFF
--- a/src/app/aether-site/site-monitor/site-monitor.component.ts
+++ b/src/app/aether-site/site-monitor/site-monitor.component.ts
@@ -145,7 +145,7 @@ export class SiteMonitorComponent
 
         // Filter for ENBs
         this.thisSite['small-cell'].forEach((enb) => {
-            baseUrl += `&var-enb=${enb['small-cell-id']}`;
+            baseUrl += `&var-enb=${enb['display-name']}`;
         });
 
         return baseUrl;


### PR DESCRIPTION
Small cell display name is stored in ROC and can match upto mme_number_of_enb_attached - enbname label to fetch metrics