### PR TITLE
Make the Site list view responsive to width changes

### DIFF
--- a/src/app/aether-site/site/site.component.html
+++ b/src/app/aether-site/site/site.component.html
@@ -53,11 +53,17 @@
 
         <!-- Description Column -->
         <ng-container matColumnDef="description" id="descColumn">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>
+            <th
+                mat-header-cell
+                *matHeaderCellDef
+                mat-sort-header
+                class="description-col-wide"
+            >
                 Description
             </th>
             <td
                 [style]="row['for-delete-style']"
+                class="description-col-wide"
                 mat-cell
                 *matCellDef="let row"
                 [title]="row.description"
@@ -76,7 +82,13 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="small-cell-col-simple">
+                    {{ row["small-cell"].length }}
+                </p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="small-cell-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["small-cell"].length }} Small Cell(s)
@@ -122,7 +134,11 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="slice-col-simple">{{ row["slice"].length }}</p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="slice-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["slice"].length }} Slice(s)
@@ -165,7 +181,13 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="device-group-col-simple">
+                    {{ row["device-group"].length }}
+                </p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="device-group-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["device-group"].length }} Device Group(s)
@@ -210,7 +232,13 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="ip-domain-col-simple">
+                    {{ row["ip-domain"].length }}
+                </p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="ip-domain-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["ip-domain"].length }} IP Domains(s)
@@ -253,7 +281,11 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="upf-col-simple">{{ row["upf"].length }}</p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="upf-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["upf"].length }} UPF(s)
@@ -294,7 +326,11 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="sim-card-col-simple">{{ row["sim-card"].length }}</p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="sim-card-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["sim-card"].length }} SIM Card(s)
@@ -335,7 +371,11 @@
                 mat-cell
                 *matCellDef="let row"
             >
-                <mat-expansion-panel togglePosition="before">
+                <p class="device-col-simple">{{ row["device"].length }}</p>
+                <mat-expansion-panel
+                    togglePosition="before"
+                    class="device-col-wide"
+                >
                     <mat-expansion-panel-header>
                         <mat-panel-title
                             >{{ row["device"].length }} Device(s)
@@ -370,13 +410,19 @@
 
         <!-- Enterprise Column -->
         <ng-container matColumnDef="enterprise" id="EnterpriseColumn">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>
+            <th
+                mat-header-cell
+                *matHeaderCellDef
+                mat-sort-header
+                class="enterprise-col-wide"
+            >
                 Enterprise
             </th>
             <td
                 [style]="row['for-delete-style']"
                 mat-cell
                 *matCellDef="let row"
+                class="enterprise-col-wide"
             >
                 {{ row["enterprise-id"] }}
                 <mat-icon

--- a/src/app/aether-site/site/site.component.scss
+++ b/src/app/aether-site/site/site.component.scss
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: 2022-present Open Networking Foundation <info@opennetworking.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// UPF column should simplify first
+.upf-col-simple {
+    display: none;
+}
+.upf-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 100rem) {
+    .upf-col-simple {
+        display: unset;
+    }
+    .upf-col-wide {
+        display: none;
+    }
+}
+
+// Then IP Domain column
+.ip-domain-col-simple {
+    display: none;
+}
+.ip-domain-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 90rem) {
+    .ip-domain-col-simple {
+        display: unset;
+    }
+    .ip-domain-col-wide {
+        display: none;
+    }
+}
+
+// Then device-group column
+.device-group-col-simple {
+    display: none;
+}
+.device-group-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 81rem) {
+    .device-group-col-simple {
+        display: unset;
+    }
+    .device-group-col-wide {
+        display: none;
+    }
+}
+
+// Then sim-cards
+.sim-card-col-simple {
+    display: none;
+}
+.sim-card-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 73rem) {
+    .sim-card-col-simple {
+        display: unset;
+    }
+    .sim-card-col-wide {
+        display: none;
+    }
+}
+
+// Then devices
+.device-col-simple {
+    display: none;
+}
+.device-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 67rem) {
+    .device-col-simple {
+        display: unset;
+    }
+    .device-col-wide {
+        display: none;
+    }
+}
+
+// Then small-cells
+.small-cell-col-simple {
+    display: none;
+}
+.small-cell-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 59rem) {
+    .small-cell-col-simple {
+        display: unset;
+    }
+    .small-cell-col-wide {
+        display: none;
+    }
+}
+
+// Then slice
+.slice-col-simple {
+    display: none;
+}
+.slice-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 53rem) {
+    .slice-col-simple {
+        display: unset;
+    }
+    .slice-col-wide {
+        display: none;
+    }
+}
+
+// Then description disappears
+.description-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 45rem) {
+    .description-col-wide {
+        display: none;
+    }
+}
+
+// Then enterprise disappears
+.enterprise-col-wide {
+    display: unset;
+}
+
+@media screen and (max-width: 40rem) {
+    .enterprise-col-wide {
+        display: none;
+    }
+}

--- a/src/app/aether-site/site/site.component.spec.ts
+++ b/src/app/aether-site/site/site.component.spec.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import {
+    HttpClientTestingModule,
+    HttpTestingController,
+} from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatPaginatorModule } from '@angular/material/paginator';
@@ -18,8 +21,28 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { SiteComponent } from './site.component';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { HttpClient } from '@angular/common/http';
+import { Enterprises } from '../../../openapi3/aether/2.0.0/models/enterprises';
+
+const testData: Enterprises = {
+    enterprise: [
+        {
+            'enterprise-id': 'ent1',
+            'display-name': 'Enterprise Test',
+            site: [
+                {
+                    'site-id': 'site-1',
+                    'display-name': 'Site 1',
+                    description: 'The first site',
+                },
+            ],
+        },
+    ],
+};
 
 describe('SiteComponent', () => {
+    let httpClient: HttpClient;
+    let httpTestingController: HttpTestingController;
     let component: SiteComponent;
     let fixture: ComponentFixture<SiteComponent>;
 
@@ -49,12 +72,49 @@ describe('SiteComponent', () => {
     });
 
     beforeEach(() => {
+        // Inject the http service and test controller for each test
+        httpClient = TestBed.inject(HttpClient);
+        httpTestingController = TestBed.inject(HttpTestingController);
+
         fixture = TestBed.createComponent(SiteComponent);
         component = fixture.componentInstance;
+
         fixture.detectChanges();
+
+        // The following `expectOne()` will match the request's URL.
+        // If no requests or multiple requests matched that URL
+        // `expectOne()` would throw.
+        const req = httpTestingController.expectOne(
+            '/aether/v2.0.0/connectivity-service-v2/enterprises'
+        );
+
+        // Assert that the request is a GET.
+        expect(req.request.method).toEqual('GET');
+
+        // Respond with mock data, causing Observable to resolve.
+        // Subscribe callback asserts that correct data was returned.
+        req.flush(testData);
+    });
+
+    afterEach(() => {
+        // Finally, assert that there are no outstanding requests.
+        httpTestingController.verify();
     });
 
     it('should create', () => {
         expect(component).toBeTruthy();
+    });
+
+    it('should find one site', () => {
+        expect(component.dataSource.data.length).toEqual(1);
+    });
+
+    it('should find site site-1', () => {
+        expect(component.dataSource.data[0]['site-id']).toEqual('site-1');
+        expect(component.dataSource.data[0]['display-name']).toEqual('Site 1');
+        expect(component.dataSource.data[0]['description']).toEqual(
+            'The first site'
+        );
+        expect(component.dataSource.data[0]['enterprise-id']).toEqual('ent1');
     });
 });

--- a/src/app/aether-site/site/site.component.ts
+++ b/src/app/aether-site/site/site.component.ts
@@ -18,7 +18,7 @@ import { EnterprisesEnterpriseSite } from '../../../openapi3/aether/2.0.0/models
 @Component({
     selector: 'aether-site',
     templateUrl: './site.component.html',
-    styleUrls: ['../../common-profiles.component.scss'],
+    styleUrls: ['../../common-profiles.component.scss', 'site.component.scss'],
 })
 export class SiteComponent
     extends RocListBase<SiteDatasource, EnterprisesEnterpriseSite>


### PR DESCRIPTION
The site view with the new controls was ending up too wide on smaller displays and causing the view to add a scroll bar with the controls off over to the right.

This solution makes the view responsive through CSS, demoting some of the columns if less space is available